### PR TITLE
Fix "Cannot import urlquote" in Django >= 4

### DIFF
--- a/easy_pdf/rendering.py
+++ b/easy_pdf/rendering.py
@@ -8,7 +8,7 @@ import os
 from django.conf import settings
 from django.template import loader
 from django.http import HttpResponse
-from django.utils.http import urlquote
+from urllib.parse import quote
 from six import BytesIO
 
 import xhtml2pdf.default
@@ -94,7 +94,7 @@ def encode_filename(filename):
     # TODO: http://greenbytes.de/tech/webdav/rfc6266.html
     # TODO: http://greenbytes.de/tech/tc2231/
 
-    quoted = urlquote(filename)
+    quoted = quote(filename)
     if quoted == filename:
         return "filename=%s" % filename
     else:


### PR DESCRIPTION
Replace deprecated Django import by the function it was an alias for  :

See doc : https://docs.djangoproject.com/en/4.1/releases/3.0/#id3